### PR TITLE
statically check that a class is polymorphic (where needed)

### DIFF
--- a/doc/custom_rtti.adoc
+++ b/doc/custom_rtti.adoc
@@ -7,6 +7,9 @@ source:
 [source,c++]
 ----
 struct std_rtti : rtti {
+    template<class Class>
+    static constexpr auto is_polymorphic = std::is_polymorphic_v<Class>;
+
     template<typename T>
     static type_id static_type() {
         return reinterpret_cast<type_id>(&typeid(T));
@@ -32,6 +35,9 @@ struct std_rtti : rtti {
     }
 };
 ----
+
+* `is_polymorphic` is used to check if a class is polymorphic. This template is
+  required.
 
 * `static_type` is used by class registration, by `virtual_ptr`{empty}'s "final"
     constructs, and to format error and trace messages. `T` is not restricted to

--- a/doc/minimal_rtti.adoc
+++ b/doc/minimal_rtti.adoc
@@ -5,6 +5,9 @@
 
 ```c++
 struct minimal_rtti : rtti {
+    template<class Class>
+    static constexpr bool is_polymorphic = false;
+
     template<typename Class>
     static auto static_type() -> type_id;
 };
@@ -24,6 +27,15 @@ is not supported. Classes are not required to be polymorphic.
 
 ### Members
 
+
+#### is_polymorphic
+
+```c++
+template<class Class>
+static constexpr bool is_polymorphic = false;
+```
+
+This facet does not support polymorphic classes.
 
 #### static_type
 

--- a/doc/rtti.adoc
+++ b/doc/rtti.adoc
@@ -21,6 +21,15 @@ an `ostream`-like object.
 
 ### Requirements
 
+#### is_polymorphic
+
+```c++
+template<class Class>
+static constexpr bool is_polymorphic;
+```
+
+`true` if `Class` is polymorphic.
+
 #### static_type
 
 ```c++

--- a/examples/custom_rtti.cpp
+++ b/examples/custom_rtti.cpp
@@ -34,9 +34,12 @@ struct Dog : Animal {
 namespace bom = boost::openmethod;
 
 struct custom_rtti : bom::policies::rtti {
+    template<class T>
+    static constexpr bool is_polymorphic = std::is_base_of_v<Animal, T>;
+
     template<typename T>
     static auto static_type() -> bom::type_id {
-        if constexpr (std::is_base_of_v<Animal, T>) {
+        if constexpr (is_polymorphic<T>) {
             return T::static_type;
         } else {
             return 0;
@@ -45,7 +48,7 @@ struct custom_rtti : bom::policies::rtti {
 
     template<typename T>
     static auto dynamic_type(const T& obj) -> bom::type_id {
-        if constexpr (std::is_base_of_v<Animal, T>) {
+        if constexpr (is_polymorphic<T>) {
             return obj.type;
         } else {
             return 0;

--- a/include/boost/openmethod/policies.hpp
+++ b/include/boost/openmethod/policies.hpp
@@ -25,7 +25,8 @@ struct release : basic_policy<
 
 struct debug : release::add<
                    runtime_checks, basic_error_output<debug>,
-                   basic_trace_output<debug>> {};
+                   basic_trace_output<debug>>::
+                   replace<error_handler, vectored_error_handler<debug>> {};
 
 } // namespace policies
 

--- a/include/boost/openmethod/policies/minimal_rtti.hpp
+++ b/include/boost/openmethod/policies/minimal_rtti.hpp
@@ -13,6 +13,9 @@ namespace openmethod {
 namespace policies {
 
 struct minimal_rtti : virtual rtti {
+    template<class Class>
+    static constexpr bool is_polymorphic = false;
+
     template<typename T>
     static auto static_type() -> type_id {
         static char id;

--- a/include/boost/openmethod/policies/std_rtti.hpp
+++ b/include/boost/openmethod/policies/std_rtti.hpp
@@ -21,6 +21,9 @@ namespace policies {
 struct std_rtti : virtual rtti {
 #ifndef BOOST_NO_RTTI
     template<class Class>
+    static constexpr bool is_polymorphic = std::is_polymorphic_v<Class>;
+
+    template<class Class>
     static auto static_type() -> type_id {
         auto tip = &typeid(Class);
         return reinterpret_cast<type_id>(tip);

--- a/test/test_custom_rtti.cpp
+++ b/test/test_custom_rtti.cpp
@@ -39,9 +39,12 @@ struct Cat : Animal {
 };
 
 struct custom_rtti : policies::rtti {
+    template<class T>
+    static constexpr bool is_polymorphic = std::is_base_of_v<Animal, T>;
+
     template<typename T>
     static auto static_type() {
-        if constexpr (std::is_base_of_v<Animal, T>) {
+        if constexpr (is_polymorphic<T>) {
             return reinterpret_cast<type_id>(T::static_type);
         } else {
             return 0;
@@ -50,7 +53,7 @@ struct custom_rtti : policies::rtti {
 
     template<typename T>
     static auto dynamic_type(const T& obj) {
-        if constexpr (std::is_base_of_v<Animal, T>) {
+        if constexpr (is_polymorphic<T>) {
             return reinterpret_cast<type_id>(obj.type);
         } else {
             return 0;
@@ -129,9 +132,12 @@ struct Cat : Animal {
 };
 
 struct custom_rtti : policies::rtti {
+    template<class T>
+    static constexpr bool is_polymorphic = std::is_base_of_v<Animal, T>;
+
     template<typename T>
     static auto static_type() {
-        if constexpr (std::is_base_of_v<Animal, T>) {
+        if constexpr (is_polymorphic<T>) {
             return T::static_type;
         } else {
             return 666;
@@ -140,7 +146,7 @@ struct custom_rtti : policies::rtti {
 
     template<typename T>
     static auto dynamic_type(const T& obj) {
-        if constexpr (std::is_base_of_v<Animal, T>) {
+        if constexpr (is_polymorphic<T>) {
             return obj.type;
         } else {
             return 666;
@@ -277,9 +283,12 @@ struct Cat : virtual Animal {
 };
 
 struct custom_rtti : policies::rtti {
+    template<class T>
+    static constexpr bool is_polymorphic = std::is_base_of_v<Animal, T>;
+
     template<typename T>
     static auto static_type() {
-        if constexpr (std::is_base_of_v<Animal, T>) {
+        if constexpr (is_polymorphic<T>) {
             return T::static_type;
         } else {
             return 666;
@@ -288,7 +297,7 @@ struct custom_rtti : policies::rtti {
 
     template<typename T>
     static auto dynamic_type(const T& obj) {
-        if constexpr (std::is_base_of_v<Animal, T>) {
+        if constexpr (is_polymorphic<T>) {
             return obj.type;
         } else {
             return 666;
@@ -418,9 +427,12 @@ struct Cat : Animal {
 std::size_t Cat::static_type = ++Animal::last_type_id;
 
 struct custom_rtti : policies::deferred_static_rtti {
+    template<class T>
+    static constexpr bool is_polymorphic = std::is_base_of_v<Animal, T>;
+
     template<typename T>
     static auto static_type() {
-        if constexpr (std::is_base_of_v<Animal, T>) {
+        if constexpr (is_polymorphic<T>) {
             return T::static_type;
         } else {
             static type_id invalid = 0;
@@ -430,7 +442,7 @@ struct custom_rtti : policies::deferred_static_rtti {
 
     template<typename T>
     static auto dynamic_type(const T& obj) {
-        if constexpr (std::is_base_of_v<Animal, T>) {
+        if constexpr (is_polymorphic<T>) {
             return obj.type;
         } else {
             return 666;


### PR DESCRIPTION
* Restore static checks for non-polymorphic classes.
* Fix error handler in the debug policy.