### PR TITLE
fix jamfiles

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,26 @@
+# Copyright 2025 Dmitry Arkhipov (grisumbras@yandex.ru)
+# Distributed under the Boost Software License, Version 1.0.
+# https://www.boost.org/LICENSE_1_0.txt
+
+require-b2 5.2 ;
+
+constant boost_dependencies
+    : /boost/assert//boost_assert
+      /boost/config//boost_config
+      /boost/core//boost_core
+      /boost/dynamic_bitset//boost_dynamic_bitset
+      /boost/mp11//boost_mp11
+      /boost/preprocessor//boost_preprocessor
+    ;
+
+project /boost/open_method ;
+
+alias boost_open_method
+    : usage-requirements
+      <include>include
+      <library>$(boost_dependencies)
+    ;
+alias all : boost_open_method test ;
+explicit all ;
+
+call-if : boost-library open_method ;

--- a/test/Jamfile
+++ b/test/Jamfile
@@ -6,37 +6,31 @@
 #  See accompanying file LICENSE_1_0.txt or copy at
 #  http://www.boost.org/LICENSE_1_0.txt
 
+import-search /boost/config/checks ;
+
 import testing ;
-import ../../config/checks/config : requires ;
+import config : requires ;
 
 project
   : requirements
 
     [ requires cxx11_variadic_templates cxx11_template_aliases cxx11_decltype cxx11_hdr_tuple ]
 
+    <library>/boost/open_method//boost_open_method
+
     <warnings>extra
 
-    <toolset>msvc:<warnings-as-errors>on
-    <toolset>gcc:<warnings-as-errors>on
-    <toolset>clang:<warnings-as-errors>on
+    # <toolset>msvc:<warnings-as-errors>on
+    # <toolset>gcc:<warnings-as-errors>on
+    # <toolset>clang:<warnings-as-errors>on
   ;
 
 # list
-run test_blackbox.cpp ;
-run test_compiler.cpp ;
-run test_core.cpp ;
-run test_custom_rtti.cpp ;
-run test_member_method.cpp ;
-run test_namespaces.cpp ;
-run test_pointer_to_method.cpp ;
-run test_rolex.cpp ;
-run test_static_list.cpp ;
-run test_virtual_ptr_all.cpp ;
-run test_virtual_ptr_basic.cpp ;
-run test_virtual_ptr_value_semantics.cpp ;
-run test_shared_virtual_ptr_value_semantics.cpp ;
-run test_unique_virtual_ptr_value_semantics.cpp ;
+for local src in [ glob test_*.cpp ]
+{
+  run $(src) ;
+}
 
 # quick (for CI)
-alias quick : blackbox ;
+alias quick : test_blackbox ;
 explicit quick ;


### PR DESCRIPTION
This fixes several problems with the jamfiles.

1. Adds a root `build.jam` for modular support.
2. Fixes errors in test/Jamfile.
3. Comments `warnings-as-errors` properties, because the tests don't build otherwise.