### PR TITLE
uniform method signature - core

### DIFF
--- a/examples/core_api.cpp
+++ b/examples/core_api.cpp
@@ -27,7 +27,8 @@ using namespace boost::openmethod;
 class BOOST_OPENMETHOD_NAME(poke);
 
 using poke = method<
-    BOOST_OPENMETHOD_NAME(poke)(std::ostream&, virtual_ptr<Animal>), void>;
+    BOOST_OPENMETHOD_NAME(poke),
+    auto(std::ostream&, virtual_ptr<Animal>)->void>;
 // end::method[]
 
 // tag::poke_cat[]
@@ -68,7 +69,7 @@ auto pet_dog(std::ostream& os, virtual_ptr<Dog> dog) {
 }
 
 using pet = method<
-    BOOST_OPENMETHOD_NAME(pet)(std::ostream&, virtual_ptr<Animal>), void>;
+    BOOST_OPENMETHOD_NAME(pet), auto(std::ostream&, virtual_ptr<Animal>)->void>;
 
 BOOST_OPENMETHOD_REGISTER(pet::override<pet_cat, pet_dog>);
 

--- a/examples/slides.cpp
+++ b/examples/slides.cpp
@@ -260,7 +260,7 @@ using namespace nodes;
 use_classes<Node, Number, Plus, Times> use_node_classes;
 
 struct value_id;
-using value = method<value_id(virtual_ptr<const Node>), int>;
+using value = method<value_id, auto (virtual_ptr<const Node>)->int>;
 
 auto number_value(virtual_ptr<const Number> node) -> int {
   return node->val;

--- a/include/boost/openmethod/macros.hpp
+++ b/include/boost/openmethod/macros.hpp
@@ -22,6 +22,21 @@ struct enable_forwarder<
     using type = ReturnType;
 };
 
+template<class...>
+struct va_args;
+
+template<class ReturnType, class Registry>
+struct va_args<ReturnType, Registry> {
+    using return_type = ReturnType;
+    using registry = Registry;
+};
+
+template<class ReturnType>
+struct va_args<ReturnType> {
+    using return_type = ReturnType;
+    using registry = macro_default_registry;
+};
+
 } // namespace boost::openmethod::detail
 
 #define BOOST_OPENMETHOD_GENSYM BOOST_PP_CAT(openmethod_gensym_, __COUNTER__)
@@ -43,9 +58,15 @@ struct enable_forwarder<
     typename ::boost::openmethod::detail::enable_forwarder<                    \
         void,                                                                  \
         ::boost::openmethod::method<                                           \
-            BOOST_OPENMETHOD_NAME(NAME) ARGS, __VA_ARGS__>,                    \
+            BOOST_OPENMETHOD_NAME(NAME),                                       \
+            ::boost::openmethod::detail::va_args<__VA_ARGS__>::return_type     \
+                ARGS,                                                          \
+            ::boost::openmethod::detail::va_args<__VA_ARGS__>::registry>,      \
         typename ::boost::openmethod::method<                                  \
-            BOOST_OPENMETHOD_NAME(NAME) ARGS, __VA_ARGS__>,                    \
+            BOOST_OPENMETHOD_NAME(NAME),                                       \
+            ::boost::openmethod::detail::va_args<__VA_ARGS__>::return_type     \
+                ARGS,                                                          \
+            ::boost::openmethod::detail::va_args<__VA_ARGS__>::registry>,      \
         ForwarderParameters...>::type                                          \
         BOOST_OPENMETHOD_GUIDE(NAME)(ForwarderParameters && ... args);         \
     template<typename... ForwarderParameters>                                  \
@@ -53,13 +74,23 @@ struct enable_forwarder<
         typename ::boost::openmethod::detail::enable_forwarder<                \
             void,                                                              \
             ::boost::openmethod::method<                                       \
-                BOOST_OPENMETHOD_NAME(NAME) ARGS, __VA_ARGS__>,                \
+                BOOST_OPENMETHOD_NAME(NAME),                                   \
+                ::boost::openmethod::detail::va_args<__VA_ARGS__>::return_type \
+                    ARGS,                                                      \
+                ::boost::openmethod::detail::va_args<__VA_ARGS__>::registry>,  \
             typename ::boost::openmethod::method<                              \
-                BOOST_OPENMETHOD_NAME(NAME) ARGS, __VA_ARGS__>::return_type,   \
+                BOOST_OPENMETHOD_NAME(NAME),                                   \
+                ::boost::openmethod::detail::va_args<__VA_ARGS__>::return_type \
+                    ARGS,                                                      \
+                ::boost::openmethod::detail::va_args<__VA_ARGS__>::registry>:: \
+                return_type,                                                   \
             ForwarderParameters...>::type {                                    \
-        return ::boost::openmethod::                                           \
-            method<BOOST_OPENMETHOD_NAME(NAME) ARGS, __VA_ARGS__>::fn(         \
-                std::forward<ForwarderParameters>(args)...);                   \
+        return ::boost::openmethod::method<                                    \
+            BOOST_OPENMETHOD_NAME(NAME),                                       \
+            ::boost::openmethod::detail::va_args<__VA_ARGS__>::return_type     \
+                ARGS,                                                          \
+            ::boost::openmethod::detail::va_args<__VA_ARGS__>::registry>::     \
+            fn(std::forward<ForwarderParameters>(args)...);                    \
     }
 
 #define BOOST_OPENMETHOD_DETAIL_LOCATE_METHOD(NAME, ARGS)                      \

--- a/test/test_blackbox.cpp
+++ b/test/test_blackbox.cpp
@@ -479,7 +479,7 @@ BOOST_OPENMETHOD_CLASSES(Animal, Dog, Bulldog);
 
 struct BOOST_OPENMETHOD_NAME(poke);
 using poke =
-    method<BOOST_OPENMETHOD_NAME(poke)(virtual_<Animal&>), std::string>;
+    method<BOOST_OPENMETHOD_NAME(poke), auto(virtual_<Animal&>)->std::string>;
 
 auto poke_dog(Dog&) -> std::string {
     return "bark";
@@ -637,10 +637,10 @@ void fn(Class&...) {
 BOOST_OPENMETHOD_CLASSES(Animal, Dog, Cat, test_registry);
 
 BOOST_AUTO_TEST_CASE(initialize_report) {
-    using poke = method<poke_(virtual_<Animal&>), void, test_registry>;
-    using pet = method<pet_(virtual_<Animal&>), void, test_registry>;
+    using poke = method<poke_, auto(virtual_<Animal&>)->void, test_registry>;
+    using pet = method<pet_, auto(virtual_<Animal&>)->void, test_registry>;
     using meet = method<
-        meet_(virtual_<Animal&>, virtual_<Animal&>), void, test_registry>;
+        meet_, auto(virtual_<Animal&>, virtual_<Animal&>)->void, test_registry>;
 
     auto report = initialize<test_registry>().report;
     BOOST_TEST(report.not_implemented == 3u);

--- a/test/test_compiler.cpp
+++ b/test/test_compiler.cpp
@@ -216,11 +216,11 @@ struct M;
 
 #define ADD_METHOD(CLASS)                                                      \
     auto& BOOST_PP_CAT(m_, CLASS) =                                            \
-        method<CLASS(virtual_<CLASS&>), void, test_registry>::fn;
+        method<CLASS, auto(virtual_<CLASS&>)->void, test_registry>::fn;
 
 #define ADD_METHOD_N(CLASS, N)                                                 \
     auto& BOOST_PP_CAT(BOOST_PP_CAT(m_, CLASS), N) =                           \
-        method<M<N>(virtual_<CLASS&>), void, test_registry>::fn;
+        method<M<N>, auto(virtual_<CLASS&>)->void, test_registry>::fn;
 
 BOOST_AUTO_TEST_CASE(test_assign_slots_a_b1_c) {
     using test_registry = test_registry_<__COUNTER__>;

--- a/test/test_member_method.cpp
+++ b/test/test_member_method.cpp
@@ -34,7 +34,8 @@ struct Payroll {
   private:
     struct BOOST_OPENMETHOD_NAME(pay);
     using pay_method = method<
-        BOOST_OPENMETHOD_NAME(pay)(Payroll*, virtual_<const Role&>), void>;
+        BOOST_OPENMETHOD_NAME(pay),
+        auto(Payroll*, virtual_<const Role&>)->void>;
 
     void pay_employee(const Employee&) {
         balance -= 2000;

--- a/test/test_virtual_ptr_dispatch.cpp
+++ b/test/test_virtual_ptr_dispatch.cpp
@@ -214,10 +214,9 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
 
     BOOST_OPENMETHOD_REGISTER(
         use_classes<Player, Warrior, Object, Axe, Bear, Registry>);
-    ;
     using poke = method<
-        BOOST_OPENMETHOD_NAME(poke)(virtual_ptr<Player, Registry>), std::string,
-        Registry>;
+        BOOST_OPENMETHOD_NAME(poke),
+        auto(virtual_ptr<Player, Registry>)->std::string, Registry>;
     BOOST_OPENMETHOD_REGISTER(
         typename poke::template override<
             poke_bear<virtual_ptr<Player, Registry>>>);
@@ -275,17 +274,19 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         use_classes<Player, Warrior, Object, Axe, Bear, Registry>);
 
     using poke = method<
-        BOOST_OPENMETHOD_NAME(poke)(virtual_ptr<Player, Registry>), std::string,
-        Registry>;
+        BOOST_OPENMETHOD_NAME(poke),
+        auto(virtual_ptr<Player, Registry>)->std::string, Registry>;
     BOOST_OPENMETHOD_REGISTER(
         typename poke::template override<
             poke_bear<virtual_ptr<Player, Registry>>>);
 
     using fight = method<
-        BOOST_OPENMETHOD_NAME(fight)(
+        BOOST_OPENMETHOD_NAME(fight),
+        auto(
             virtual_ptr<Player, Registry>, virtual_ptr<Object, Registry>,
-            virtual_ptr<Player, Registry>),
-        std::string, Registry>;
+            virtual_ptr<Player, Registry>)
+            ->std::string,
+        Registry>;
     BOOST_OPENMETHOD_REGISTER(
         typename fight::template override<fight_bear<
             virtual_ptr<Player, Registry>, virtual_ptr<Object, Registry>,
@@ -316,19 +317,21 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(
         use_classes<Player, Warrior, Object, Axe, Bear, Registry>);
 
     using poke = method<
-        BOOST_OPENMETHOD_NAME(poke)(shared_virtual_ptr<Player, Registry>),
-        std::string, Registry>;
+        BOOST_OPENMETHOD_NAME(poke),
+        auto(shared_virtual_ptr<Player, Registry>)->std::string, Registry>;
 
     BOOST_OPENMETHOD_REGISTER(
         typename poke::template override<
             poke_bear<shared_virtual_ptr<Player, Registry>>>);
 
     using fight = method<
-        BOOST_OPENMETHOD_NAME(fight)(
+        BOOST_OPENMETHOD_NAME(fight),
+        auto(
             shared_virtual_ptr<Player, Registry>,
             shared_virtual_ptr<Object, Registry>,
-            shared_virtual_ptr<Player, Registry>),
-        std::string, Registry>;
+            shared_virtual_ptr<Player, Registry>)
+            ->std::string,
+        Registry>;
 
     BOOST_OPENMETHOD_REGISTER(
         typename fight::template override<fight_bear<

--- a/test/test_virtual_ptr_value_semantics.hpp
+++ b/test/test_virtual_ptr_value_semantics.hpp
@@ -40,7 +40,7 @@ template<class Registry>
 void init_test() {
     BOOST_OPENMETHOD_REGISTER(use_classes<Animal, Cat, Dog, Registry>);
     struct id;
-    (void)&method<id(virtual_ptr<Animal, Registry>), void, Registry>::fn;
+    (void)&method<id, auto(virtual_ptr<Animal, Registry>)->void, Registry>::fn;
     boost::openmethod::initialize<Registry>();
 }
 


### PR DESCRIPTION
Related to https://github.com/jll63/Boost.OpenMethod/issues/10

Make `method` use the actual function type as its second parameter. I.e. what used to read  
`method<Name(Parameters...), ReturnType, Registry>` is now `method<Name, auto(Parameters...)->ReturnType, Registry>` (or `method<Name, ReturnType(Parameters...), Registry>`). This aligns better with other constructs which work in terms of method-id then method-signature. It also better corresponds to the method-id's goal, which is to discriminate between different methods with the same signature.

As for switching the macros to `BOOST_OPENMETHOD(id, (Args&&... args)->ReturnType)`, the idea is still being debated.