### PR TITLE
catch up with boost-ci

### DIFF
--- a/test/Jamfile
+++ b/test/Jamfile
@@ -30,7 +30,7 @@ project
 
 alias unit_test_framework
     : # sources
-        /boost/test//boost_unit_test_framework/<warnings>off
+        /boost/test//boost_unit_test_framework/<warnings-as-errors>off
     ;
 
 for local src in [ glob test_*.cpp ]

--- a/test/cmake_test/CMakeLists.txt
+++ b/test/cmake_test/CMakeLists.txt
@@ -12,8 +12,18 @@ set(__ignore__ ${CMAKE_C_COMPILER})
 set(__ignore__ ${CMAKE_C_FLAGS})
 
 if(BOOST_CI_INSTALL_TEST)
-    # Boost as a package (https://github.com/boostorg/cmake#using-boost-after-building-and-installing-it-with-cmake)
-    find_package(Boost CONFIG REQUIRED COMPONENTS openmethod)
+# Header-only libraries:
+    # B2 does not (yet) create/install CMake targets for them, so users are supposed to use the generic Boost::headers target
+    if(BOOST_CI_INSTALLED_BY STREQUAL "B2")
+        find_package(Boost REQUIRED)
+        add_library(_boost_openmethod INTERFACE)
+        target_link_libraries(_boost_openmethod INTERFACE Boost::headers)
+        target_compile_features(_boost_openmethod INTERFACE cxx_std_17)
+        add_library(Boost::openmethod ALIAS _boost_openmethod)
+    else()
+      # Boost as a package (https://github.com/boostorg/cmake#using-boost-after-building-and-installing-it-with-cmake)
+      find_package(Boost CONFIG REQUIRED COMPONENTS openmethod)
+    endif()
 elseif(BOOST_CI_INSTALL_MODULE_TEST)
     # Boost.OpenMethod as a package
     find_package(boost_openmethod CONFIG REQUIRED)

--- a/test/mix_release_debug/lib.cpp
+++ b/test/mix_release_debug/lib.cpp
@@ -16,7 +16,3 @@
 using namespace boost::openmethod;
 
 BOOST_OPENMETHOD_CLASSES(Animal, Cat);
-
-BOOST_OPENMETHOD_OVERRIDE(poke, (virtual_ptr<Cat>, std::ostream& os), void) {
-    os << "hiss";
-}

--- a/test/test_rolex.cpp
+++ b/test/test_rolex.cpp
@@ -6,11 +6,13 @@
 #include <boost/openmethod.hpp>
 #include <boost/openmethod/initialize.hpp>
 
+#define BOOST_TEST_MODULE test_rolex
+#include <boost/test/unit_test.hpp>
+
 using boost::openmethod::virtual_ptr;
 
 struct Role {
-    virtual ~Role() {
-    }
+    virtual ~Role() {}
 };
 
 struct Employee : Role {
@@ -24,8 +26,7 @@ struct Manager : Employee {
 struct Founder : Role {};
 
 struct Expense {
-    virtual ~Expense() {
-    }
+    virtual ~Expense() {}
 };
 
 struct Public : Expense {};
@@ -39,6 +40,7 @@ BOOST_OPENMETHOD_CLASSES(
     PrivateJet);
 
 BOOST_OPENMETHOD(pay, (virtual_ptr<Employee>), double);
+
 BOOST_OPENMETHOD(
     approve, (virtual_ptr<const Role>, virtual_ptr<const Expense>, double),
     bool);
@@ -75,14 +77,6 @@ BOOST_OPENMETHOD_OVERRIDE(
     return true;
 }
 
-auto main() -> int {
-    boost::openmethod::initialize();
-}
-
-auto call_pay(Employee& emp) -> double {
-    return pay(emp);
-}
-
 auto Employee::pay() -> double {
     return 3000;
 }
@@ -91,10 +85,100 @@ auto Manager::pay() -> double {
     return Employee::pay() + 2000;
 }
 
+auto call_pay(Employee& emp) -> double {
+    return pay(emp);
+}
+
 auto call_pay_vfunc(Employee& emp) -> double {
     return emp.pay();
 }
 
 auto call_approve(const Role& r, const Expense& e, double a) -> bool {
     return approve(r, e, a);
+}
+
+BOOST_AUTO_TEST_CASE(pay_employee) {
+    boost::openmethod::initialize();
+    Employee e;
+    BOOST_TEST(pay(e) == 3000);
+    BOOST_TEST(call_pay(e) == 3000);
+    BOOST_TEST(call_pay_vfunc(e) == 3000);
+}
+
+BOOST_AUTO_TEST_CASE(pay_manager_calls_next) {
+    boost::openmethod::initialize();
+    Manager m;
+    BOOST_TEST(pay(m) == 5000);
+    BOOST_TEST(call_pay(m) == 5000);
+    BOOST_TEST(call_pay_vfunc(m) == 5000);
+}
+
+BOOST_AUTO_TEST_CASE(approve_employee) {
+    boost::openmethod::initialize();
+    Employee e;
+    Bus bus;
+    Metro metro;
+    Taxi taxi;
+    PrivateJet jet;
+    // Employee may take public transport
+    BOOST_TEST(approve(e, bus, 10) == true);
+    BOOST_TEST(approve(e, metro, 10) == true);
+    // Employee may not take taxi or private jet
+    BOOST_TEST(approve(e, taxi, 10) == false);
+    BOOST_TEST(approve(e, jet, 10) == false);
+}
+
+BOOST_AUTO_TEST_CASE(approve_manager) {
+    boost::openmethod::initialize();
+    Manager m;
+    Bus bus;
+    Metro metro;
+    Taxi taxi;
+    PrivateJet jet;
+    // Manager inherits employee's public transport approval
+    BOOST_TEST(approve(m, bus, 10) == true);
+    BOOST_TEST(approve(m, metro, 10) == true);
+    // Manager may also take a taxi
+    BOOST_TEST(approve(m, taxi, 10) == true);
+    // Manager may not take a private jet
+    BOOST_TEST(approve(m, jet, 10) == false);
+}
+
+BOOST_AUTO_TEST_CASE(approve_founder) {
+    boost::openmethod::initialize();
+    Founder f;
+    Bus bus;
+    Metro metro;
+    Taxi taxi;
+    PrivateJet jet;
+    // Founder approves all expenses
+    BOOST_TEST(approve(f, bus, 10) == true);
+    BOOST_TEST(approve(f, metro, 10) == true);
+    BOOST_TEST(approve(f, taxi, 10) == true);
+    BOOST_TEST(approve(f, jet, 10) == true);
+}
+
+BOOST_AUTO_TEST_CASE(approve_base_role_denied) {
+    boost::openmethod::initialize();
+    Role r;
+    Bus bus;
+    Taxi taxi;
+    PrivateJet jet;
+    // Base Role catches all — nothing approved
+    BOOST_TEST(approve(r, bus, 10) == false);
+    BOOST_TEST(approve(r, taxi, 10) == false);
+    BOOST_TEST(approve(r, jet, 10) == false);
+}
+
+BOOST_AUTO_TEST_CASE(approve_via_wrapper) {
+    boost::openmethod::initialize();
+    Employee e;
+    Manager m;
+    Founder f;
+    Bus bus;
+    Taxi taxi;
+    BOOST_TEST(call_approve(e, bus, 10) == true);
+    BOOST_TEST(call_approve(e, taxi, 10) == false);
+    BOOST_TEST(call_approve(m, taxi, 10) == true);
+    BOOST_TEST(call_approve(f, taxi, 10) == true);
 }


### PR DESCRIPTION
Catch up with boost-ci:
- fix cmake test
- handle gcc-16 warning-as-error when building unit_test
- improve coverage