### PR TITLE
CI: gate docs deploy on triggering_actor, not repository_owner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,5 +125,5 @@ jobs:
           path: doc/html
 
       - name: Deploy to GitHub Pages (jll63)
-        if: matrix.os == 'ubuntu-latest' && github.repository_owner == 'jll63'
+        if: matrix.os == 'ubuntu-latest' && github.triggering_actor == 'jll63'
         uses: actions/deploy-pages@v4


### PR DESCRIPTION
The GitHub Pages deploy step is guarded by github.repository_owner == 'jll63', which is always true for the fork regardless of who triggered the run. As a result the deploy fired on PRs opened by outside contributors and failed on missing permissions. Key the condition on github.triggering_actor so only runs initiated by jll63 deploy; other actors' runs skip the step cleanly.